### PR TITLE
Add QSPI driver for MT25QL128A

### DIFF
--- a/QSPI_Drivers/MT25QL128A/quadspi.c
+++ b/QSPI_Drivers/MT25QL128A/quadspi.c
@@ -1,0 +1,473 @@
+/* USER CODE BEGIN 0 */
+static uint8_t QSPI_WriteEnable(void);
+static uint8_t QSPI_AutoPollingMemReady(uint32_t Timeout);
+static uint8_t QSPI_Configuration(void);
+static uint8_t QSPI_ResetChip(void);
+/* USER CODE END 0 */
+
+/* USER CODE BEGIN 1 */
+
+/* QUADSPI init function */
+uint8_t
+CSP_QUADSPI_Init(void) {
+
+    //prepare QSPI peripheral for ST-Link Utility operations
+	hqspi.Instance = QUADSPI;
+    if (HAL_QSPI_DeInit(&hqspi) != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    MX_QUADSPI_Init();
+
+    if (QSPI_ResetChip() != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    HAL_Delay(1);
+
+    if (QSPI_AutoPollingMemReady(HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    if (QSPI_WriteEnable() != HAL_OK) {
+
+        return HAL_ERROR;
+    }
+
+    if (QSPI_Configuration() != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    if (QSPI_AutoPollingMemReady(HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    return HAL_OK;
+}
+
+uint8_t
+CSP_QSPI_Erase_Chip(void) {
+
+    QSPI_CommandTypeDef sCommand;
+
+    if (QSPI_WriteEnable() != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    /* Erasing Sequence --------------------------------- */
+    sCommand.Instruction = CHIP_ERASE_CMD;
+    sCommand.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+    sCommand.AddressSize = QSPI_ADDRESS_24_BITS;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_NONE;
+    sCommand.Address = 0;
+    sCommand.DataMode = QSPI_DATA_NONE;
+    sCommand.DummyCycles = 0;
+
+    if (HAL_QSPI_Command(&hqspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+        != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    if (QSPI_AutoPollingMemReady(QUADSPI_MAX_ERASE_TIMEOUT) != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    return HAL_OK;
+}
+
+static uint8_t
+QSPI_AutoPollingMemReady(uint32_t Timeout) {
+
+    QSPI_CommandTypeDef sCommand;
+    QSPI_AutoPollingTypeDef sConfig;
+
+    /* Configure automatic polling mode to wait for memory ready ------ */
+    sCommand.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+    sCommand.Instruction = READ_STATUS_REG_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_NONE;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DataMode = QSPI_DATA_1_LINE;
+    sCommand.DummyCycles = 0;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+
+    sConfig.Match = 0x00;
+    sConfig.Mask = 0x01;
+    sConfig.MatchMode = QSPI_MATCH_MODE_AND;
+    sConfig.StatusBytesSize = 1;
+    sConfig.Interval = 0x10;
+    sConfig.AutomaticStop = QSPI_AUTOMATIC_STOP_ENABLE;
+
+    if (HAL_QSPI_AutoPolling(&hqspi, &sCommand, &sConfig, Timeout) != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    return HAL_OK;
+}
+
+static uint8_t
+QSPI_WriteEnable(void) {
+
+    QSPI_CommandTypeDef sCommand;
+    QSPI_AutoPollingTypeDef sConfig;
+
+    /* Enable write operations ------------------------------------------ */
+    sCommand.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+    sCommand.Instruction = WRITE_ENABLE_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_NONE;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DataMode = QSPI_DATA_NONE;
+    sCommand.DummyCycles = 0;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+
+    if (HAL_QSPI_Command(&hqspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+        != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    /* Configure automatic polling mode to wait for write enabling ---- */
+    sConfig.Match = 0x02;
+    sConfig.Mask = 0x02;
+    sConfig.MatchMode = QSPI_MATCH_MODE_AND;
+    sConfig.StatusBytesSize = 1;
+    sConfig.Interval = 0x10;
+    sConfig.AutomaticStop = QSPI_AUTOMATIC_STOP_ENABLE;
+
+    sCommand.Instruction = READ_STATUS_REG_CMD;
+    sCommand.DataMode = QSPI_DATA_1_LINE;
+    if (HAL_QSPI_AutoPolling(&hqspi, &sCommand, &sConfig,
+                             HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    return HAL_OK;
+}
+
+/*Enable quad mode and set dummy cycles count*/
+static uint8_t
+QSPI_Configuration(void) {
+
+    QSPI_CommandTypeDef sCommand;
+    uint16_t reg;
+
+    sCommand.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+    sCommand.Instruction = READ_CONFIGURATION_REG_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_NONE;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DataMode = QSPI_DATA_1_LINE;
+    sCommand.DummyCycles = 0;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+    sCommand.NbData = 2;
+
+    if (HAL_QSPI_Command(&hqspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+        != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    if (HAL_QSPI_Receive(&hqspi, (uint8_t*)(&reg),
+                         HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    if (QSPI_WriteEnable() != HAL_OK) {
+
+        return HAL_ERROR;
+    }
+
+    /*set dummy cycles*/
+    MODIFY_REG(reg, 0xF0F0, ((DUMMY_CLOCK_CYCLES_READ_QUAD << 4) |
+                             (DUMMY_CLOCK_CYCLES_READ_QUAD << 12)));
+
+    sCommand.Instruction = WRITE_VOL_CFG_REG_CMD;
+
+    if (HAL_QSPI_Command(&hqspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+        != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    if (HAL_QSPI_Transmit(&hqspi, (uint8_t*)(&reg),
+                          HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+        return HAL_ERROR;
+    }
+    return HAL_OK;
+}
+
+uint8_t
+CSP_QSPI_EraseSector(uint32_t EraseStartAddress, uint32_t EraseEndAddress) {
+
+    QSPI_CommandTypeDef sCommand;
+
+    EraseStartAddress = EraseStartAddress
+                        - EraseStartAddress % MEMORY_SECTOR_SIZE;
+
+    /* Erasing Sequence -------------------------------------------------- */
+    sCommand.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+    sCommand.AddressSize = QSPI_ADDRESS_24_BITS;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+    sCommand.Instruction = SECTOR_ERASE_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_1_LINE;
+
+    sCommand.DataMode = QSPI_DATA_NONE;
+    sCommand.DummyCycles = 0;
+
+    while (EraseEndAddress >= EraseStartAddress) {
+        sCommand.Address = (EraseStartAddress & 0x0FFFFFFF);
+
+        if (QSPI_WriteEnable() != HAL_OK) {
+            return HAL_ERROR;
+        }
+
+        if (HAL_QSPI_Command(&hqspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+            != HAL_OK) {
+            return HAL_ERROR;
+        }
+        EraseStartAddress += MEMORY_SECTOR_SIZE;
+
+        if (QSPI_AutoPollingMemReady(HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+            return HAL_ERROR;
+        }
+    }
+
+    return HAL_OK;
+}
+
+uint8_t
+CSP_QSPI_WriteMemory(uint8_t* buffer, uint32_t address, uint32_t buffer_size) {
+
+    QSPI_CommandTypeDef sCommand;
+    uint32_t end_addr, current_size, current_addr;
+
+    /* Calculation of the size between the write address and the end of the page */
+    current_addr = 0;
+
+    while (current_addr <= address) {
+        current_addr += MEMORY_PAGE_SIZE;
+    }
+    current_size = current_addr - address;
+
+    /* Check if the size of the data is less than the remaining place in the page */
+    if (current_size > buffer_size) {
+        current_size = buffer_size;
+    }
+
+    /* Initialize the adress variables */
+    current_addr = address;
+    end_addr = address + buffer_size;
+
+    sCommand.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+    sCommand.AddressSize = QSPI_ADDRESS_24_BITS;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+    sCommand.Instruction = QUAD_IN_FAST_PROG_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_1_LINE;
+    sCommand.DataMode = QSPI_DATA_4_LINES;
+    sCommand.NbData = buffer_size;
+    sCommand.Address = address;
+    sCommand.DummyCycles = 0;
+
+    /* Perform the write page by page */
+    do {
+        sCommand.Address = current_addr;
+        sCommand.NbData = current_size;
+
+        if (current_size == 0) {
+            return HAL_OK;
+        }
+
+        /* Enable write operations */
+        if (QSPI_WriteEnable() != HAL_OK) {
+            return HAL_ERROR;
+        }
+
+        /* Configure the command */
+        if (HAL_QSPI_Command(&hqspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+            != HAL_OK) {
+            return HAL_ERROR;
+        }
+
+        /* Transmission of the data */
+        if (HAL_QSPI_Transmit(&hqspi, buffer, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+            return HAL_ERROR;
+        }
+
+        /* Configure automatic polling mode to wait for end of program */
+        if (QSPI_AutoPollingMemReady(HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+            return HAL_ERROR;
+        }
+
+        /* Update the address and size variables for next page programming */
+        current_addr += current_size;
+        buffer += current_size;
+        current_size =
+            ((current_addr + MEMORY_PAGE_SIZE) > end_addr) ?
+            (end_addr - current_addr) : MEMORY_PAGE_SIZE;
+    } while (current_addr <= end_addr);
+
+    return HAL_OK;
+}
+
+uint8_t
+CSP_QSPI_EnableMemoryMappedMode(void) {
+
+    QSPI_CommandTypeDef sCommand;
+    QSPI_MemoryMappedTypeDef sMemMappedCfg;
+
+    /* Enable Memory-Mapped mode-------------------------------------------------- */
+
+    sCommand.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+    sCommand.AddressSize = QSPI_ADDRESS_24_BITS;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_1_LINE;
+    sCommand.DataMode = QSPI_DATA_4_LINES;
+    sCommand.NbData = 0;
+    sCommand.Address = 0;
+    sCommand.Instruction = QUAD_OUT_FAST_READ_CMD;
+    sCommand.DummyCycles = DUMMY_CLOCK_CYCLES_READ_QUAD;
+
+    sMemMappedCfg.TimeOutActivation = QSPI_TIMEOUT_COUNTER_DISABLE;
+
+    if (HAL_QSPI_MemoryMapped(&hqspi, &sCommand, &sMemMappedCfg) != HAL_OK) {
+        return HAL_ERROR;
+    }
+    return HAL_OK;
+}
+
+static uint8_t
+QSPI_ResetChip() {
+    QSPI_CommandTypeDef sCommand;
+    uint32_t temp = 0;
+    /* Erasing Sequence -------------------------------------------------- */
+    sCommand.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+    sCommand.AddressSize = QSPI_ADDRESS_24_BITS;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+    sCommand.Instruction = RESET_ENABLE_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_NONE;
+    sCommand.Address = 0;
+    sCommand.DataMode = QSPI_DATA_NONE;
+    sCommand.DummyCycles = 0;
+
+    if (HAL_QSPI_Command(&hqspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+        != HAL_OK) {
+        return HAL_ERROR;
+    }
+    for (temp = 0; temp < 0x2f; temp++) {
+        __NOP();
+    }
+
+    sCommand.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+    sCommand.AddressSize = QSPI_ADDRESS_24_BITS;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+    sCommand.Instruction = RESET_EXECUTE_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_NONE;
+    sCommand.Address = 0;
+    sCommand.DataMode = QSPI_DATA_NONE;
+    sCommand.DummyCycles = 0;
+
+    if (HAL_QSPI_Command(&hqspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+        != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    /* Erasing Sequence -------------------------------------------------- */
+    sCommand.InstructionMode = QSPI_INSTRUCTION_2_LINES;
+    sCommand.AddressSize = QSPI_ADDRESS_24_BITS;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+    sCommand.Instruction = RESET_ENABLE_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_NONE;
+    sCommand.Address = 0;
+    sCommand.DataMode = QSPI_DATA_NONE;
+    sCommand.DummyCycles = 0;
+
+    if (HAL_QSPI_Command(&hqspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+        != HAL_OK) {
+        return HAL_ERROR;
+    }
+    for (temp = 0; temp < 0x2f; temp++) {
+        __NOP();
+    }
+
+    sCommand.InstructionMode = QSPI_INSTRUCTION_2_LINES;
+    sCommand.AddressSize = QSPI_ADDRESS_24_BITS;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+    sCommand.Instruction = RESET_EXECUTE_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_NONE;
+    sCommand.Address = 0;
+    sCommand.DataMode = QSPI_DATA_NONE;
+    sCommand.DummyCycles = 0;
+
+    if (HAL_QSPI_Command(&hqspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+        != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    /* Erasing Sequence -------------------------------------------------- */
+    sCommand.InstructionMode = QSPI_INSTRUCTION_4_LINES;
+    sCommand.AddressSize = QSPI_ADDRESS_24_BITS;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+    sCommand.Instruction = RESET_ENABLE_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_NONE;
+    sCommand.Address = 0;
+    sCommand.DataMode = QSPI_DATA_NONE;
+    sCommand.DummyCycles = 0;
+
+    if (HAL_QSPI_Command(&hqspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+        != HAL_OK) {
+        return HAL_ERROR;
+    }
+    for (temp = 0; temp < 0x2f; temp++) {
+        __NOP();
+    }
+
+    sCommand.InstructionMode = QSPI_INSTRUCTION_4_LINES;
+    sCommand.AddressSize = QSPI_ADDRESS_24_BITS;
+    sCommand.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
+    sCommand.DdrMode = QSPI_DDR_MODE_DISABLE;
+    sCommand.DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
+    sCommand.SIOOMode = QSPI_SIOO_INST_EVERY_CMD;
+    sCommand.Instruction = RESET_EXECUTE_CMD;
+    sCommand.AddressMode = QSPI_ADDRESS_NONE;
+    sCommand.Address = 0;
+    sCommand.DataMode = QSPI_DATA_NONE;
+    sCommand.DummyCycles = 0;
+
+    if (HAL_QSPI_Command(&hqspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE)
+        != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    return HAL_OK;
+}
+
+/* USER CODE END 1 */

--- a/QSPI_Drivers/MT25QL128A/quadspi.h
+++ b/QSPI_Drivers/MT25QL128A/quadspi.h
@@ -1,0 +1,35 @@
+/* USER CODE BEGIN Private defines */
+
+uint8_t CSP_QUADSPI_Init(void);
+uint8_t CSP_QSPI_EraseSector(uint32_t EraseStartAddress, uint32_t EraseEndAddress);
+uint8_t CSP_QSPI_WriteMemory(uint8_t* buffer, uint32_t address, uint32_t buffer_size);
+uint8_t CSP_QSPI_EnableMemoryMappedMode(void);
+uint8_t CSP_QSPI_Erase_Chip (void);
+
+/* USER CODE END Private defines */
+
+/* USER CODE BEGIN Prototypes */
+
+/*MT25QL128A memory parameters*/
+#define MEMORY_FLASH_SIZE               0x1000000 /* 128 MBits */
+#define MEMORY_SECTOR_SIZE              0x10000  /* 64kBytes */
+#define MEMORY_PAGE_SIZE                0x100   /* 256 bytes */
+
+
+/*MT25QL128A commands */
+#define WRITE_ENABLE_CMD 0x06
+#define READ_STATUS_REG_CMD 0x05
+#define WRITE_VOL_CFG_REG_CMD 0x81
+#define SECTOR_ERASE_CMD 0xD8
+#define CHIP_ERASE_CMD 0xC7
+#define QUAD_IN_FAST_PROG_CMD 0x32
+#define READ_CONFIGURATION_REG_CMD 0x85
+#define QUAD_OUT_FAST_READ_CMD 0x6B
+#define DUMMY_CLOCK_CYCLES_READ_QUAD 8
+#define RESET_ENABLE_CMD 0x66
+#define RESET_EXECUTE_CMD 0x99
+
+/*MT25QL128A timeouts*/
+#define QUADSPI_MAX_ERASE_TIMEOUT 460000 /* 460s max */
+
+/* USER CODE END Prototypes */


### PR DESCRIPTION
Based on the existing MT25QL512 quadspi driver. Minor changes to suit the MT25QL128A memory. Tested with custom PCB.